### PR TITLE
Use cfg-expr 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- Updated `cfg-expr` to 0.2.0, so only 1.41.0 built-in targets are fully supported
+
 ## [0.1.1] - 2020-02-04
 ### Added
 - Added `PkgSpec`, an implementation of cargo's [package id specifications](https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["cargo", "metadata", "graph"]
 # Used for acquiring and deserializing `cargo metadata` output
 cargo_metadata = "0.9.1"
 # Used to parse and evaluate cfg() expressions for dependencies
-cfg-expr = "0.1.0"
+cfg-expr = "0.2.0"
 # Used to create and traverse graph structures
 petgraph = "0.5.0"
 # Used for checking version requirements

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/EmbarkStudios/krates/workflows/CI/badge.svg)](https://github.com/EmbarkStudios/krates/actions?workflow=CI)
 [![Crates.io](https://img.shields.io/crates/v/krates.svg)](https://crates.io/crates/krates)
 [![Docs](https://docs.rs/krates/badge.svg)](https://docs.rs/krates)
+[![Rust Version](https://img.shields.io/badge/Rust%20Version-1.41.0-blue.svg)](https://forge.rust-lang.org/release/platform-support.html)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://embark.dev)
 


### PR DESCRIPTION
Only builtin-targets of 1.41 are fully supported now