### PR TITLE
Fix metadata again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- Align `semver` version with the same one used by `cargo_metadata`, again.
+
 ## [0.3.1] - 2020-07-18
 ### Fixed
 - Align `semver` version with the same one used by `cargo_metadata`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["cargo", "metadata", "graph"]
 
 [dependencies]
 # Used for acquiring and deserializing `cargo metadata` output
-cargo_metadata = "0.10"
+cargo_metadata = "=0.11.0"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.4"
 # Used to create and traverse graph structures

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ ignore = []
 unlicensed = "deny"
 allow = [
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "MIT",
 ]
 copyleft = "deny"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,7 @@ where
                 o => o,
             }) {
                 Ok(i) | Err(i) => {
+                    #[allow(clippy::reversed_empty_ranges)]
                     if i >= raw_nodes.len() || raw_nodes[i].weight.krate.name() != name {
                         0..0
                     } else {


### PR DESCRIPTION
Fix cargo_metadata after 0.10.1 was yanked.

Resolves: #10 