### PR TITLE
Update `cargo_metadata` to v0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["cfg-expr/targets"]
 
 [dependencies]
 # Used for acquiring and/or deserializing `cargo metadata` output
-cargo_metadata = "0.12"
+cargo_metadata = "0.13"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.7"
 # Used to create and traverse graph structures

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,6 @@ targets = ["cfg-expr/targets"]
 [dependencies]
 # Used for acquiring and/or deserializing `cargo metadata` output
 cargo_metadata = "0.13"
-# Used for Cargo.lock paths
-camino = "1"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.7"
 # Used to create and traverse graph structures

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ targets = ["cfg-expr/targets"]
 [dependencies]
 # Used for acquiring and/or deserializing `cargo metadata` output
 cargo_metadata = "0.13"
+# Used for Cargo.lock paths
+camino = "1"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.7"
 # Used to create and traverse graph structures

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
 
+pub use camino;
 pub use cargo_metadata as cm;
 pub use cfg_expr;
 
@@ -37,6 +38,7 @@ pub use cfg_expr::target_lexicon;
 pub use petgraph;
 pub use semver;
 
+use camino::{Utf8Path, Utf8PathBuf};
 use petgraph::{graph::NodeIndex, Direction};
 
 mod builder;
@@ -152,7 +154,7 @@ impl fmt::Display for Edge {
 pub struct Krates<N = cm::Package, E = Edge> {
     graph: petgraph::Graph<Node<N>, E>,
     workspace_members: Vec<Kid>,
-    lock_file: std::path::PathBuf,
+    lock_file: Utf8PathBuf,
 }
 
 #[allow(clippy::len_without_is_empty)]
@@ -166,7 +168,7 @@ impl<N, E> Krates<N, E> {
     /// Path to the Cargo.lock file for the crate or workspace where the graph
     /// metadata was acquired from
     #[inline]
-    pub fn lock_path(&self) -> &std::path::PathBuf {
+    pub fn lock_path(&self) -> &Utf8Path {
         &self.lock_file
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
 
-pub use camino;
 pub use cargo_metadata as cm;
 pub use cfg_expr;
 
@@ -38,7 +37,7 @@ pub use cfg_expr::target_lexicon;
 pub use petgraph;
 pub use semver;
 
-use camino::{Utf8Path, Utf8PathBuf};
+pub use cm::camino::{self, Utf8Path, Utf8PathBuf};
 use petgraph::{graph::NodeIndex, Direction};
 
 mod builder;


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

1. Updates the `cargo_metadata` crate to v0.13.
    Since v0.13, `cargo_metadata` uses [`camino::Utf8PathBuf`](https://docs.rs/camino/1.0.2/camino/struct.Utf8PathBuf.html) for file paths. (https://github.com/oli-obk/cargo_metadata/pull/152)
2. Changes the return type of `Krates::lock_path` to <code>&[camino::Utf8Path](https://docs.rs/camino/1.0.2/camino/struct.Utf8Path.html)</code>.
3. Re-exports `camino`, though it's done by `cargo_metadata`.

### Related Issues

Nothing.
