### PR TITLE
chore: bump cargo_metadata to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ targets = ["cfg-expr/targets"]
 
 [dependencies]
 # Used for acquiring and/or deserializing `cargo metadata` output
-cargo_metadata = "0.14"
+cargo_metadata = "0.15"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.10"
 # Used to create and traverse graph structures


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Bump cargo_metadata to 0.15

Hi lovelies, could we bump cargo_metadata to 0.15 pretty please ty vm :) :unicorn: 

### Related Issues

I am wishing to bump to 0.15 in cargo-geiger but krates is still 0.14 leading to some type errors

I've tested that it all works locally with cargo-geiger - 
I have bump PR waiting here wired to future 0.15 and waiiting krates bump to 0.15:
https://github.com/rust-secure-code/cargo-geiger/pull/339