### PR TITLE
Fixup Krates API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#52](https://github.com/EmbarkStudios/krates/pull/52) updated cfg-expr to 0.12.
+- [PR#52](https://github.com/EmbarkStudios/krates/pull/52) changed `Krates::search_matches` and `Krates::search_by_name` to use `impl Into<String>` for the name to search, so that the lifetime of it is not paired with the graph itself.
+
 ## [0.12.5] - 2022-11-08
 ### Fixed
 - [PR#51](https://github.com/EmbarkStudios/krates/pull/51) resolved [#50](https://github.com/EmbarkStudios/krates/issues/50) by no longer treating the feature set in the index as authoritative, but rather just merging in the keys that were not already located in the feature set from the crate itself. This would mean that features that are present in both but with different sub-features from the index will now be lost, but that can be fixed later if it is actually an issue.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,12 @@ default = []
 prefer-index = ["crates-index"]
 # Adds support for filtering target specific dependencies
 targets = ["cfg-expr/targets"]
-#features = []
 
 [dependencies]
 # Used for acquiring and/or deserializing `cargo metadata` output
 cargo_metadata = "0.15"
 # Used to parse and evaluate cfg() expressions for dependencies
-cfg-expr = "0.11"
+cfg-expr = "0.12"
 # Allows inspection of the cargo registry index(ices)
 crates-index = { version = "0.18", optional = true, default-features = false, features = [
     "parallel",

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,10 @@ copyleft = "deny"
 
 [bans]
 multiple-versions = "deny"
+skip = [
+    # Doesn't matter
+    { name = "hermit-abi" },
+]
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
This makes a change to the `Krates::search_matches` and `Krates::search_by_name` so that the name being searched doesn't have its lifetime paired with the graph's to avoid annoying usage. Unfortunately this means a heap copy, but this is only used in the case the name is not already a heap string.

Also updates cfg-expr 0.11 -> 0.12