### PR TITLE
Add configuration for git index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#54](https://github.com/EmbarkStudios/krates/pull/54) fixed an issue where the crates.io index was unconditionally opened, and synced, if the `prefer-index` feature was enabled, causing long stalls if using the crates.io sparse index instead.
+
 ## [0.13.0] - 2023-04-04
 ### Changed
 - [PR#53](https://github.com/EmbarkStudios/krates/pull/53) updated `cfg-expr` to 0.14 and `crates-index` to 0.19.

--- a/deny.toml
+++ b/deny.toml
@@ -18,8 +18,10 @@ multiple-versions = "deny"
 skip = [
     # Doesn't matter
     { name = "hermit-abi" },
+]
+skip-tree = [
     # dev only but still sigh
-    { name = "windows-sys", version = "=0.42.0" },
+    { name = "windows-sys", version = "<0.48.0" },
 ]
 
 [sources]

--- a/src/builder/index.rs
+++ b/src/builder/index.rs
@@ -5,6 +5,18 @@ pub(super) struct ComboIndex {
 
 impl ComboIndex {
     #[inline]
+    pub(super) fn open(allow_git: bool) -> Self {
+        Self {
+            git: if allow_git {
+                crates_index::Index::new_cargo_default().ok()
+            } else {
+                None
+            },
+            http: crates_index::SparseIndex::from_url("sparse+https://index.crates.io/").ok(),
+        }
+    }
+
+    #[inline]
     fn krate(&self, name: &str) -> Option<crates_index::Crate> {
         // Attempt http first, as this will be the default in future cargo versions
         // and using it when it is not the defaul indicates the user has opted in
@@ -12,14 +24,6 @@ impl ComboIndex {
             .as_ref()
             .and_then(|h| h.crate_from_cache(name).ok())
             .or_else(|| self.git.as_ref().and_then(|g| g.crate_(name)))
-    }
-}
-
-#[inline]
-pub(super) fn open() -> ComboIndex {
-    ComboIndex {
-        git: crates_index::Index::new_cargo_default().ok(),
-        http: crates_index::SparseIndex::from_url("sparse+https://index.crates.io/").ok(),
     }
 }
 


### PR DESCRIPTION
The crates.io git index is incredibly expensive to fetch if it not present or old, and, as of 1.70.0, is _not even needed_, but this crate's usage caused a full crates.io git index sync if the `prefer-index` feature was enabled, regardless of whether the sparse index was used, causing really bad interaction in clean CI environments.

Rather than detecting cargo version/env in this crate, we defer to the calling crate, and instead just default to false.