### PR TITLE
Refactor crates.io index support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        features: ["--all-features", null]
+        features: ["--all-features", "--features prefer-index", null]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,6 @@ jobs:
       # the entries we want are in the sparse cache, otherwise the bug_repro test
       # fails.
       - run: cargo fetch --manifest-path tests/bug/Cargo.toml
-        if: matrix.features == '--all-features'
       - name: cargo test build
         run: cargo build --tests --release ${{ matrix.features }}
       - name: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ exclude = [".github", "tests"]
 [features]
 default = []
 # Uses the index as the source of truth for what features are available for a crate
-prefer-index = ["crates-index"]
+prefer-index = []
+# Uses crates-index to read the index rather than rely on a user-provided implementation
+with-crates-index = ["prefer-index", "crates-index"]
 # Adds support for filtering target specific dependencies
 targets = ["cfg-expr/targets"]
 
@@ -29,9 +31,7 @@ cargo_metadata = "0.15"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.15"
 # Allows inspection of the cargo registry index(ices)
-crates-index = { version = "0.19", optional = true, default-features = false, features = [
-    "parallel",
-] }
+crates-index = { version = "0.19", optional = true, default-features = false }
 # Used to create and traverse graph structures
 petgraph = "0.6"
 # Used for checking version requirements

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -627,13 +627,15 @@ impl Builder {
         let resolved = md.resolve.ok_or(Error::NoResolveGraph)?;
 
         #[cfg(feature = "prefer-index")]
-        let index = self.crates_io_index.ok_or(Error::NoIndexImplementation)?;
+        let index = self.crates_io_index;
 
         let mut packages = md.packages;
         packages.sort_by(|a, b| a.id.cmp(&b.id));
 
         #[cfg(feature = "prefer-index")]
-        index.prepare_cache_entries(packages.iter().map(|pkg| pkg.name.clone()).collect());
+        if let Some(index) = &index {
+            index.prepare_cache_entries(packages.iter().map(|pkg| pkg.name.clone()).collect());
+        }
 
         let mut workspace_members = md.workspace_members;
         workspace_members.sort();
@@ -853,7 +855,9 @@ impl Builder {
             };
 
             #[cfg(feature = "prefer-index")]
-            index::fix_features(index.as_ref(), krate);
+            if let Some(index) = &index {
+                index::fix_features(index.as_ref(), krate);
+            }
 
             // Cargo puts out a flat list of the enabled features, but we need
             // to use the declared features on the crate itself to figure out

--- a/src/builder/index.rs
+++ b/src/builder/index.rs
@@ -1,36 +1,181 @@
-pub(super) struct ComboIndex {
-    git: Option<crates_index::Index>,
-    http: Option<crates_index::SparseIndex>,
+use std::collections::{BTreeMap, BTreeSet};
+
+pub type FeaturesMap = BTreeMap<String, Vec<String>>;
+
+#[derive(Copy, Clone)]
+pub enum IndexKind {
+    Sparse,
+    Git,
 }
 
-impl ComboIndex {
-    #[inline]
-    pub(super) fn open(allow_git: bool) -> Self {
+#[derive(Clone)]
+pub struct IndexKrateVersion {
+    pub version: semver::Version,
+    pub features: FeaturesMap,
+}
+
+#[derive(Clone)]
+pub struct IndexKrate {
+    pub versions: Vec<IndexKrateVersion>,
+}
+
+pub trait CratesIoIndex {
+    fn index_krate(&self, _name: &str) -> Option<IndexKrate> {
+        None
+    }
+
+    fn index_krate_features(
+        &self,
+        _name: &str,
+        _version: &semver::Version,
+        _on_features: &mut dyn FnMut(Option<&FeaturesMap>),
+    ) {
+    }
+
+    /// Allows an implementation to read local cache entries for crates to avoid
+    /// individual lookups
+    fn prepare_cache_entries(&self, _krate_set: BTreeSet<String>) {}
+}
+
+pub struct CachingIndex<TIndex: CratesIoIndex> {
+    cache: std::sync::RwLock<BTreeMap<String, Option<IndexKrate>>>,
+    inner: TIndex,
+}
+
+impl<TIndex: CratesIoIndex> CachingIndex<TIndex> {
+    /// Creates a caching index around the specified index
+    pub fn new(inner: TIndex) -> Self {
         Self {
-            git: if allow_git {
-                crates_index::Index::new_cargo_default().ok()
-            } else {
-                None
-            },
-            http: crates_index::SparseIndex::from_url("sparse+https://index.crates.io/").ok(),
+            cache: std::sync::RwLock::new(BTreeMap::new()),
+            inner,
         }
     }
 
+    /// Clears the in-memory cache
     #[inline]
-    fn krate(&self, name: &str) -> Option<crates_index::Crate> {
-        // Attempt http first, as this will be the default in future cargo versions
-        // and using it when it is not the defaul indicates the user has opted in
-        self.http
-            .as_ref()
-            .and_then(|h| h.crate_from_cache(name).ok())
-            .or_else(|| self.git.as_ref().and_then(|g| g.crate_(name)))
+    pub fn clear(&self) {
+        self.cache.write().unwrap().clear();
     }
 }
+
+impl<TIndex: CratesIoIndex> CratesIoIndex for CachingIndex<TIndex> {
+    fn index_krate_features(
+        &self,
+        name: &str,
+        version: &semver::Version,
+        on_features: &mut dyn FnMut(Option<&FeaturesMap>),
+    ) {
+        loop {
+            if let Some(index_krate) = self.cache.read().unwrap().get(name) {
+                let fm = index_krate.as_ref().and_then(|ik| {
+                    ik.versions
+                        .iter()
+                        .find_map(|ikv| (&ikv.version == version).then_some(&ikv.features))
+                });
+                on_features(fm);
+                return;
+            } else {
+                self.cache
+                    .write()
+                    .unwrap()
+                    .insert(name.to_owned(), self.inner.index_krate(name));
+            }
+        }
+    }
+
+    fn prepare_cache_entries(&self, krate_set: BTreeSet<String>) {
+        let mut cache = self.cache.write().unwrap();
+
+        for krate_name in krate_set {
+            let krate = self.inner.index_krate(&krate_name);
+            cache.insert(krate_name, krate);
+        }
+    }
+}
+
+#[cfg(feature = "with-crates-index")]
+mod external {
+    use super::*;
+    use crates_index as ci;
+    use std::path::Path;
+
+    pub fn sparse(cargo_home: Option<&Path>) -> Result<CachingIndex<Index>, crate::Error> {
+        let sparse = if let Some(cargo_home) = cargo_home {
+            ci::SparseIndex::with_path(cargo_home, ci::CRATES_IO_HTTP_INDEX)?
+        } else {
+            ci::SparseIndex::new_cargo_default()?
+        };
+
+        Ok(CachingIndex::new(Index::Sparse(sparse)))
+    }
+
+    /// Converts from a [`crates_index::Crate`] to an [`IndexKrate`].
+    ///
+    /// All versions _should_ be parsed since crates.io verifies semver on upload,
+    /// but just in case, we just skip versions that we can't parse as we still
+    /// have the local information already
+    fn convert(krate: ci::Crate) -> IndexKrate {
+        let versions = krate
+            .versions()
+            .iter()
+            .filter_map(|kv| {
+                let version = kv.version().parse().ok()?;
+                let features = kv
+                    .features()
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+
+                Some(IndexKrateVersion { version, features })
+            })
+            .collect();
+
+        IndexKrate { versions }
+    }
+
+    pub fn git(cargo_home: Option<&Path>) -> Result<CachingIndex<Index>, crate::Error> {
+        // We would like to use the get_index_details here, but that is broken
+        // currently https://github.com/frewsxcv/rust-crates-index
+        //
+        // Luckily we can just cheat since the we only use crates.io here and
+        // can just manually specify the path
+        //let (path, url) = ci::get_index_details(ci::INDEX_GIT_URL, cargo_home)?;
+        let git = if let Some(cargo_home) = cargo_home {
+            ci::Index::with_path(
+                cargo_home.join("registry/index/github.com-1ecc6299db9ec823"),
+                ci::INDEX_GIT_URL,
+            )
+        } else {
+            ci::Index::new_cargo_default()
+        };
+
+        Ok(CachingIndex::new(Index::Git(git?)))
+    }
+
+    pub enum Index {
+        Git(ci::Index),
+        Sparse(ci::SparseIndex),
+    }
+
+    impl CratesIoIndex for Index {
+        fn index_krate(&self, name: &str) -> Option<IndexKrate> {
+            let krate = match self {
+                Self::Sparse(sparse) => sparse.crate_from_cache(name).ok()?,
+                Self::Git(git) => git.crate_(name)?,
+            };
+
+            Some(convert(krate))
+        }
+    }
+}
+
+#[cfg(feature = "with-crates-index")]
+pub use external::*;
 
 /// Due to <https://github.com/rust-lang/cargo/issues/11319>, we can't actually
 /// trust cargo to give us the correct package metadata, so we instead use the
 /// (presumably) correct data from the the index
-pub(super) fn fix_features(index: &ComboIndex, krate: &mut cargo_metadata::Package) {
+pub(super) fn fix_features(index: &dyn CratesIoIndex, krate: &mut cargo_metadata::Package) {
     if krate
         .source
         .as_ref()
@@ -39,53 +184,41 @@ pub(super) fn fix_features(index: &ComboIndex, krate: &mut cargo_metadata::Packa
         return;
     }
 
-    if let Some(entry) = index.krate(&krate.name) {
-        let features = entry.versions().iter().find_map(|v| {
-            if let Ok(iv) = v.version().parse::<semver::Version>() {
-                if iv == krate.version {
-                    Some(v.features())
+    index.index_krate_features(&krate.name, &krate.version, &mut |features| {
+        let Some(features) = features else { return; };
+
+        for (ikey, ivalue) in features {
+            if !krate.features.contains_key(ikey) {
+                krate.features.insert(ikey.clone(), ivalue.clone());
+            }
+        }
+
+        // The index entry features might not have the `dep:<crate>`
+        // used with weak features if the crate version was
+        // published with cargo <1.60.0 version, so we need to
+        // manually fix that up since we depend on that format
+        let missing_deps: Vec<_> = krate
+            .features
+            .iter()
+            .flat_map(|(_, sf)| sf.iter())
+            .filter_map(|sf| {
+                let pf = crate::ParsedFeature::from(sf.as_str());
+
+                if let super::features::Feature::Simple(simple) = pf.feat() {
+                    if krate.features.contains_key(simple) {
+                        None
+                    } else {
+                        Some(simple.to_owned())
+                    }
                 } else {
                     None
                 }
-            } else {
-                None
-            }
-        });
+            })
+            .collect();
 
-        if let Some(features) = features {
-            for (ikey, ivalue) in features {
-                if !krate.features.contains_key(ikey) {
-                    krate.features.insert(ikey.clone(), ivalue.clone());
-                }
-            }
-
-            // The index entry features might not have the `dep:<crate>`
-            // used with weak features if the crate version was
-            // published with cargo <1.60.0 version, so we need to
-            // manually fix that up since we depend on that format
-            let missing_deps: Vec<_> = krate
-                .features
-                .iter()
-                .flat_map(|(_, sf)| sf.iter())
-                .filter_map(|sf| {
-                    let pf = crate::ParsedFeature::from(sf.as_str());
-
-                    if let super::features::Feature::Simple(simple) = pf.feat() {
-                        if krate.features.contains_key(simple) {
-                            None
-                        } else {
-                            Some(simple.to_owned())
-                        }
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            for missing in missing_deps {
-                let dep_feature = format!("dep:{missing}");
-                krate.features.insert(missing, vec![dep_feature]);
-            }
+        for missing in missing_deps {
+            let dep_feature = format!("dep:{missing}");
+            krate.features.insert(missing, vec![dep_feature]);
         }
-    }
+    });
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,15 +13,25 @@ pub enum Error {
     /// Due to how the graph was built, all possible root nodes were actually
     /// filtered out, leaving an empty graph
     NoRootKrates,
+    /// The `prefer-index` feature was enabled but [`Builder::with_crates_io_index`]
+    /// was not called
+    #[cfg(feature = "prefer-index")]
+    NoIndexImplementation,
+    #[cfg(feature = "with-crates-index")]
+    CratesIndex(crates_index::Error),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NoResolveGraph => f.write_str("no resolution graph was provided"),
-            Self::Metadata(err) => write!(f, "{}", err),
-            Self::InvalidPkgSpec(err) => write!(f, "package spec was invalid: {}", err),
+            Self::Metadata(err) => write!(f, "{err}"),
+            Self::InvalidPkgSpec(err) => write!(f, "package spec was invalid: {err}"),
             Self::NoRootKrates => f.write_str("no root crates available"),
+            #[cfg(feature = "prefer-index")]
+            Self::NoIndexImplementation => f.write_str("Builder::with_crates_io_index must be called if the `prefer-index` feature is enabled"),
+            #[cfg(feature = "with-crates-index")]
+            Self::CratesIndex(err) => write!(f, "{err}"),
         }
     }
 }
@@ -30,6 +40,8 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Metadata(err) => Some(err),
+            #[cfg(feature = "with-crates-index")]
+            Self::CratesIndex(err) => Some(err),
             _ => None,
         }
     }
@@ -38,5 +50,12 @@ impl std::error::Error for Error {
 impl From<CMErr> for Error {
     fn from(e: CMErr) -> Self {
         Error::Metadata(e)
+    }
+}
+
+#[cfg(feature = "with-crates-index")]
+impl From<crates_index::Error> for Error {
+    fn from(e: crates_index::Error) -> Self {
+        Error::CratesIndex(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ mod builder;
 mod errors;
 mod pkgspec;
 
+#[cfg(feature = "prefer-index")]
+pub use builder::index;
 pub use builder::{
     features::{Feature, ParsedFeature},
     Builder, Cmd, LockOptions, NoneFilter, OnFilter, Scope, Target,

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -191,9 +191,11 @@ fn direct_dependencies() {
 }
 
 #[test]
-#[cfg(feature = "prefer-index")]
+#[cfg(feature = "with-crates-index")]
 fn bug_repro() {
-    let kb = krates::Builder::new();
+    let mut kb = krates::Builder::new();
+    kb.with_crates_io_index(None, krates::index::IndexKind::Sparse)
+        .unwrap();
 
     let grafs = util::build("bug.json", kb).unwrap();
 


### PR DESCRIPTION
Previously, if the `prefer-index` feature was enabled, `crates-index`
was used to read cache entries to fix features for crates.

However, `crates-index` can be a problematic dependency since it
requires git2 regardless of whether you use the git index or not

Using `with-crates-index` preserves the old behavior to just use
`crates-index`, however, `prefer-index` now allows users to implement
their own Index implementation if they would like leaving the choice of
git/http/etc up to the calling code