### PR TITLE
Use `tame-index`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        features: ["--all-features", "--features prefer-index", null]
+        features: ["--features targets", "--features prefer-index", null]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ exclude = [".github", "tests"]
 default = []
 # Uses the index as the source of truth for what features are available for a crate
 prefer-index = []
-# Uses crates-index to read the index rather than rely on a user-provided implementation
-with-crates-index = ["prefer-index", "crates-index"]
+# Uses tame-index to read the index rather than rely on a user-provided implementation
+with-index-impl = ["prefer-index", "tame-index"]
 # Adds support for filtering target specific dependencies
 targets = ["cfg-expr/targets"]
 
@@ -31,7 +31,7 @@ cargo_metadata = "0.15"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.15"
 # Allows inspection of the cargo registry index(ices)
-crates-index = { version = "0.19", optional = true, default-features = false }
+tame-index = { version = "0.1", optional = true, default-features = false }
 # Used to create and traverse graph structures
 petgraph = "0.6"
 # Used for checking version requirements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cargo_metadata = "0.17"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.15"
 # Allows inspection of the cargo registry index(ices)
-tame-index = { version = "0.1", optional = true, default-features = false }
+tame-index = { version = "0.2", optional = true, default-features = false }
 # Used to create and traverse graph structures
 petgraph = "0.6"
 # Used for checking version requirements
@@ -44,6 +44,3 @@ insta = "1.21"
 similar-asserts = "1.1"
 # Used to deserialize test files into metadata we can load
 serde_json = "1.0"
-
-[patch.crates-io]
-tame-index = { path = "../tame-index" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,12 @@ homepage = "https://github.com/EmbarkStudios/krates"
 keywords = ["cargo", "metadata", "graph"]
 categories = ["visualization"]
 exclude = [".github", "tests"]
+rust-version = "1.65.0"
 
 [features]
 default = []
 # Uses the index as the source of truth for what features are available for a crate
-prefer-index = []
-# Uses tame-index to read the index rather than rely on a user-provided implementation
-with-index-impl = ["prefer-index", "tame-index"]
+prefer-index = ["dep:tame-index"]
 # Adds support for filtering target specific dependencies
 targets = ["cfg-expr/targets"]
 
@@ -45,3 +44,6 @@ insta = "1.21"
 similar-asserts = "1.1"
 # Used to deserialize test files into metadata we can load
 serde_json = "1.0"
+
+[patch.crates-io]
+tame-index = { path = "../tame-index" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ targets = ["cfg-expr/targets"]
 
 [dependencies]
 # Used for acquiring and/or deserializing `cargo metadata` output
-cargo_metadata = "0.15"
+cargo_metadata = "0.17"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.15"
 # Allows inspection of the cargo registry index(ices)

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,8 @@ skip = [
 skip-tree = [
     # dev only but still sigh
     { name = "windows-sys", version = "<0.48.0" },
+    # petgraph uses an older indexmap
+    { name = "indexmap", version = "=1.9.3" },
 ]
 
 [sources]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -313,7 +313,7 @@ pub struct Builder {
     ignore_kinds: u32,
     workspace: bool,
     #[cfg(feature = "prefer-index")]
-    crates_io_index: Option<Box<dyn index::CratesIoIndex>>,
+    crates_io_index: Option<tame_index::index::ComboIndexCache>,
 }
 
 impl Builder {
@@ -490,21 +490,7 @@ impl Builder {
         self
     }
 
-    /// Specifies an implementation that can be used to query the crates.io
-    /// index to ensure that the features are all correct
-    ///
-    /// This method _must_ be called with an implementation if not using
-    /// the `with-crates-index` feature
-    #[cfg(all(feature = "prefer-index", not(feature = "with-crates-index")))]
-    pub fn with_crates_io_index(
-        &mut self,
-        crates_io_index: Box<dyn index::CratesIoIndex>,
-    ) -> &mut Self {
-        self.crates_io_index = Some(crates_io_index);
-        self
-    }
-
-    /// Configures the index implementation to use `crates-index`
+    /// Configures the index implementation`
     ///
     /// As of 1.70.0 the cargo default is to use the HTTP sparse index, which is
     /// vastly faster than the old crates.io git index, and is the recommended
@@ -514,16 +500,22 @@ impl Builder {
     /// that no fetching from the remote index is performed by this library, so
     /// it is your responsibility to have called `cargo fetch` or similar to have
     /// an up to date index cache at the location provided
-    #[cfg(all(feature = "prefer-index", feature = "with-crates-index"))]
+    #[cfg(feature = "prefer-index")]
     pub fn with_crates_io_index(
         &mut self,
-        cargo_home: Option<&Path>,
+        cargo_home: Option<tame_index::PathBuf>,
         index_kind: index::IndexKind,
     ) -> Result<&mut Self, Error> {
-        self.crates_io_index = Some(match index_kind {
-            index::IndexKind::Sparse => Box::new(index::sparse(cargo_home)?),
-            index::IndexKind::Git => Box::new(index::git(cargo_home)?),
-        });
+        let url = match index_kind {
+            index::IndexKind::Sparse => tame_index::IndexUrl::CratesIoSparse,
+            index::IndexKind::Git => tame_index::IndexUrl::CratesIoGit,
+        };
+
+        let index = tame_index::index::ComboIndexCache::new(
+            tame_index::IndexLocation::new(url).with_root(cargo_home),
+        )?;
+
+        self.crates_io_index = Some(index);
         Ok(self)
     }
 
@@ -626,16 +618,15 @@ impl Builder {
     {
         let resolved = md.resolve.ok_or(Error::NoResolveGraph)?;
 
-        #[cfg(feature = "prefer-index")]
-        let index = self.crates_io_index;
-
         let mut packages = md.packages;
         packages.sort_by(|a, b| a.id.cmp(&b.id));
 
+        // Load all the cache entries from disk for all the possible _unique_
+        // crates in the graph so that we don't need to access disk again
         #[cfg(feature = "prefer-index")]
-        if let Some(index) = &index {
-            index.prepare_cache_entries(packages.iter().map(|pkg| pkg.name.clone()).collect());
-        }
+        let index = self.crates_io_index.map(|index| {
+            index::CachingIndex::new(index, packages.iter().map(|pkg| pkg.name.clone()).collect())
+        });
 
         let mut workspace_members = md.workspace_members;
         workspace_members.sort();
@@ -856,7 +847,7 @@ impl Builder {
 
             #[cfg(feature = "prefer-index")]
             if let Some(index) = &index {
-                index::fix_features(index.as_ref(), krate);
+                index::fix_features(index, krate);
             }
 
             // Cargo puts out a flat list of the enabled features, but we need

--- a/src/builder/index.rs
+++ b/src/builder/index.rs
@@ -93,11 +93,10 @@ impl<TIndex: CratesIoIndex> CratesIoIndex for CachingIndex<TIndex> {
     }
 }
 
-#[cfg(feature = "with-crates-index")]
+#[cfg(feature = "with-index-impl")]
 mod external {
     use super::*;
-    use crates_index as ci;
-    use std::path::Path;
+    use tame_index as ti;
 
     pub fn sparse(cargo_home: Option<&Path>) -> Result<CachingIndex<Index>, crate::Error> {
         let sparse = if let Some(cargo_home) = cargo_home {
@@ -169,7 +168,7 @@ mod external {
     }
 }
 
-#[cfg(feature = "with-crates-index")]
+#[cfg(feature = "with-index-impl")]
 pub use external::*;
 
 /// Due to <https://github.com/rust-lang/cargo/issues/11319>, we can't actually

--- a/src/builder/index.rs
+++ b/src/builder/index.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use tame_index::index::ComboIndexCache;
 
 pub type FeaturesMap = BTreeMap<String, Vec<String>>;
 
@@ -11,7 +12,7 @@ pub enum IndexKind {
 #[derive(Clone)]
 pub struct IndexKrateVersion {
     pub version: semver::Version,
-    pub features: FeaturesMap,
+    pub features: std::sync::Arc<FeaturesMap>,
 }
 
 #[derive(Clone)]
@@ -19,162 +20,52 @@ pub struct IndexKrate {
     pub versions: Vec<IndexKrateVersion>,
 }
 
-pub trait CratesIoIndex {
-    fn index_krate(&self, _name: &str) -> Option<IndexKrate> {
-        None
-    }
-
-    fn index_krate_features(
-        &self,
-        _name: &str,
-        _version: &semver::Version,
-        _on_features: &mut dyn FnMut(Option<&FeaturesMap>),
-    ) {
-    }
-
-    /// Allows an implementation to read local cache entries for crates to avoid
-    /// individual lookups
-    fn prepare_cache_entries(&self, _krate_set: BTreeSet<String>) {}
+pub struct CachingIndex {
+    cache: BTreeMap<String, Option<IndexKrate>>,
 }
 
-pub struct CachingIndex<TIndex: CratesIoIndex> {
-    cache: std::sync::RwLock<BTreeMap<String, Option<IndexKrate>>>,
-    inner: TIndex,
-}
-
-impl<TIndex: CratesIoIndex> CachingIndex<TIndex> {
+impl CachingIndex {
     /// Creates a caching index around the specified index
-    pub fn new(inner: TIndex) -> Self {
-        Self {
-            cache: std::sync::RwLock::new(BTreeMap::new()),
-            inner,
-        }
-    }
-
-    /// Clears the in-memory cache
-    #[inline]
-    pub fn clear(&self) {
-        self.cache.write().unwrap().clear();
-    }
-}
-
-impl<TIndex: CratesIoIndex> CratesIoIndex for CachingIndex<TIndex> {
-    fn index_krate_features(
-        &self,
-        name: &str,
-        version: &semver::Version,
-        on_features: &mut dyn FnMut(Option<&FeaturesMap>),
-    ) {
-        loop {
-            if let Some(index_krate) = self.cache.read().unwrap().get(name) {
-                let fm = index_krate.as_ref().and_then(|ik| {
-                    ik.versions
-                        .iter()
-                        .find_map(|ikv| (&ikv.version == version).then_some(&ikv.features))
-                });
-                on_features(fm);
-                return;
-            } else {
-                self.cache
-                    .write()
-                    .unwrap()
-                    .insert(name.to_owned(), self.inner.index_krate(name));
-            }
-        }
-    }
-
-    fn prepare_cache_entries(&self, krate_set: BTreeSet<String>) {
-        let mut cache = self.cache.write().unwrap();
-
-        for krate_name in krate_set {
-            let krate = self.inner.index_krate(&krate_name);
-            cache.insert(krate_name, krate);
-        }
-    }
-}
-
-#[cfg(feature = "with-index-impl")]
-mod external {
-    use super::*;
-    use tame_index as ti;
-
-    pub fn sparse(cargo_home: Option<&Path>) -> Result<CachingIndex<Index>, crate::Error> {
-        let sparse = if let Some(cargo_home) = cargo_home {
-            ci::SparseIndex::with_path(cargo_home, ci::CRATES_IO_HTTP_INDEX)?
-        } else {
-            ci::SparseIndex::new_cargo_default()?
-        };
-
-        Ok(CachingIndex::new(Index::Sparse(sparse)))
-    }
-
-    /// Converts from a [`crates_index::Crate`] to an [`IndexKrate`].
-    ///
-    /// All versions _should_ be parsed since crates.io verifies semver on upload,
-    /// but just in case, we just skip versions that we can't parse as we still
-    /// have the local information already
-    fn convert(krate: ci::Crate) -> IndexKrate {
-        let versions = krate
-            .versions()
-            .iter()
-            .filter_map(|kv| {
-                let version = kv.version().parse().ok()?;
-                let features = kv
-                    .features()
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
+    pub fn new(inner: ComboIndexCache, krates: BTreeSet<String>) -> Self {
+        let mut cache = BTreeMap::new();
+        for name in krates {
+            let read = || -> Option<IndexKrate> {
+                let name = name.as_str().try_into().ok()?;
+                let krate = inner.cached_krate(name).ok()??;
+                let versions = krate
+                    .versions
+                    .into_iter()
+                    .map(|kv| IndexKrateVersion {
+                        version: kv.version,
+                        features: kv.features,
+                    })
                     .collect();
 
-                Some(IndexKrateVersion { version, features })
-            })
-            .collect();
-
-        IndexKrate { versions }
-    }
-
-    pub fn git(cargo_home: Option<&Path>) -> Result<CachingIndex<Index>, crate::Error> {
-        // We would like to use the get_index_details here, but that is broken
-        // currently https://github.com/frewsxcv/rust-crates-index
-        //
-        // Luckily we can just cheat since the we only use crates.io here and
-        // can just manually specify the path
-        //let (path, url) = ci::get_index_details(ci::INDEX_GIT_URL, cargo_home)?;
-        let git = if let Some(cargo_home) = cargo_home {
-            ci::Index::with_path(
-                cargo_home.join("registry/index/github.com-1ecc6299db9ec823"),
-                ci::INDEX_GIT_URL,
-            )
-        } else {
-            ci::Index::new_cargo_default()
-        };
-
-        Ok(CachingIndex::new(Index::Git(git?)))
-    }
-
-    pub enum Index {
-        Git(ci::Index),
-        Sparse(ci::SparseIndex),
-    }
-
-    impl CratesIoIndex for Index {
-        fn index_krate(&self, name: &str) -> Option<IndexKrate> {
-            let krate = match self {
-                Self::Sparse(sparse) => sparse.crate_from_cache(name).ok()?,
-                Self::Git(git) => git.crate_(name)?,
+                Some(IndexKrate { versions })
             };
 
-            Some(convert(krate))
+            let krate = read();
+            cache.insert(name, krate);
         }
+
+        Self { cache }
+    }
+
+    fn index_krate_features(&self, name: &str, version: &semver::Version) -> Option<&FeaturesMap> {
+        self.cache.get(name).and_then(|ik| {
+            ik.as_ref().and_then(|ik| {
+                ik.versions
+                    .iter()
+                    .find_map(|ikv| (&ikv.version == version).then_some(ikv.features.as_ref()))
+            })
+        })
     }
 }
-
-#[cfg(feature = "with-index-impl")]
-pub use external::*;
 
 /// Due to <https://github.com/rust-lang/cargo/issues/11319>, we can't actually
 /// trust cargo to give us the correct package metadata, so we instead use the
 /// (presumably) correct data from the the index
-pub(super) fn fix_features(index: &dyn CratesIoIndex, krate: &mut cargo_metadata::Package) {
+pub(super) fn fix_features(index: &CachingIndex, krate: &mut cargo_metadata::Package) {
     if krate
         .source
         .as_ref()
@@ -183,41 +74,39 @@ pub(super) fn fix_features(index: &dyn CratesIoIndex, krate: &mut cargo_metadata
         return;
     }
 
-    index.index_krate_features(&krate.name, &krate.version, &mut |features| {
-        let Some(features) = features else { return; };
+    let Some(features) = index.index_krate_features(&krate.name, &krate.version) else { return; };
 
-        for (ikey, ivalue) in features {
-            if !krate.features.contains_key(ikey) {
-                krate.features.insert(ikey.clone(), ivalue.clone());
-            }
+    for (ikey, ivalue) in features {
+        if !krate.features.contains_key(ikey) {
+            krate.features.insert(ikey.clone(), ivalue.clone());
         }
+    }
 
-        // The index entry features might not have the `dep:<crate>`
-        // used with weak features if the crate version was
-        // published with cargo <1.60.0 version, so we need to
-        // manually fix that up since we depend on that format
-        let missing_deps: Vec<_> = krate
-            .features
-            .iter()
-            .flat_map(|(_, sf)| sf.iter())
-            .filter_map(|sf| {
-                let pf = crate::ParsedFeature::from(sf.as_str());
+    // The index entry features might not have the `dep:<crate>`
+    // used with weak features if the crate version was
+    // published with cargo <1.60.0 version, so we need to
+    // manually fix that up since we depend on that format
+    let missing_deps: Vec<_> = krate
+        .features
+        .iter()
+        .flat_map(|(_, sf)| sf.iter())
+        .filter_map(|sf| {
+            let pf = crate::ParsedFeature::from(sf.as_str());
 
-                if let super::features::Feature::Simple(simple) = pf.feat() {
-                    if krate.features.contains_key(simple) {
-                        None
-                    } else {
-                        Some(simple.to_owned())
-                    }
-                } else {
+            if let super::features::Feature::Simple(simple) = pf.feat() {
+                if krate.features.contains_key(simple) {
                     None
+                } else {
+                    Some(simple.to_owned())
                 }
-            })
-            .collect();
+            } else {
+                None
+            }
+        })
+        .collect();
 
-        for missing in missing_deps {
-            let dep_feature = format!("dep:{missing}");
-            krate.features.insert(missing, vec![dep_feature]);
-        }
-    });
+    for missing in missing_deps {
+        let dep_feature = format!("dep:{missing}");
+        krate.features.insert(missing, vec![dep_feature]);
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,12 +13,9 @@ pub enum Error {
     /// Due to how the graph was built, all possible root nodes were actually
     /// filtered out, leaving an empty graph
     NoRootKrates,
-    /// The `prefer-index` feature was enabled but [`Builder::with_crates_io_index`]
-    /// was not called
+    /// An error occurred trying to open or read the crates.io index
     #[cfg(feature = "prefer-index")]
-    NoIndexImplementation,
-    #[cfg(feature = "with-crates-index")]
-    CratesIndex(crates_index::Error),
+    Index(tame_index::Error),
 }
 
 impl fmt::Display for Error {
@@ -29,9 +26,7 @@ impl fmt::Display for Error {
             Self::InvalidPkgSpec(err) => write!(f, "package spec was invalid: {err}"),
             Self::NoRootKrates => f.write_str("no root crates available"),
             #[cfg(feature = "prefer-index")]
-            Self::NoIndexImplementation => f.write_str("Builder::with_crates_io_index must be called if the `prefer-index` feature is enabled"),
-            #[cfg(feature = "with-crates-index")]
-            Self::CratesIndex(err) => write!(f, "{err}"),
+            Self::Index(err) => write!(f, "{err}"),
         }
     }
 }
@@ -53,9 +48,9 @@ impl From<CMErr> for Error {
     }
 }
 
-#[cfg(feature = "with-crates-index")]
-impl From<crates_index::Error> for Error {
-    fn from(e: crates_index::Error) -> Self {
-        Error::CratesIndex(e)
+#[cfg(feature = "prefer-index")]
+impl From<tame_index::Error> for Error {
+    fn from(e: tame_index::Error) -> Self {
+        Error::Index(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ impl fmt::Display for Edge {
 pub struct Krates<N = cm::Package, E = Edge> {
     graph: petgraph::Graph<Node<N>, E, petgraph::Directed, u32>,
     workspace_members: Vec<Kid>,
-    lock_file: Utf8PathBuf,
+    workspace_root: Utf8PathBuf,
     /// We split the graph between crate and feature nodes, but keep the crates
     /// grouped together in the front since most queries are against them
     krates_end: usize,
@@ -207,11 +207,10 @@ impl<N, E> Krates<N, E> {
         self.krates_end
     }
 
-    /// Path to the Cargo.lock file for the crate or workspace where the graph
-    /// metadata was acquired from
+    /// Path to the root of the workspace where the graph metadata was acquired from
     #[inline]
-    pub fn lock_path(&self) -> &Utf8Path {
-        &self.lock_file
+    pub fn workspace_root(&self) -> &Utf8Path {
+        &self.workspace_root
     }
 
     /// Get access to the raw petgraph

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -246,40 +246,8 @@ mod prefer_index {
         assert_features!(md, "conv", ["default", "std"]);
     }
 
-    /// Validates an external index implementation can fix features
-    #[test]
-    #[cfg(not(feature = "with-crates-index"))]
-    fn uses_external_index_impl() {
-        use krates::index::{self, FeaturesMap};
-        struct Custom(FeaturesMap);
-
-        impl index::CratesIoIndex for Custom {
-            fn index_krate_features(
-                &self,
-                name: &str,
-                version: &semver::Version,
-                on_features: &mut dyn FnMut(Option<&FeaturesMap>),
-            ) {
-                if name == "conv" && version == &semver::Version::new(0, 3, 3) {
-                    on_features(Some(&self.0))
-                } else {
-                    on_features(None)
-                }
-            }
-        }
-
-        let mut fm = FeaturesMap::new();
-        fm.insert("default".into(), vec!["std".into()]);
-        fm.insert("std".into(), vec!["custom_derive/std".into()]);
-
-        let mut b = krates::Builder::new();
-        b.with_crates_io_index(Box::new(Custom(fm)));
-        confirm_index_snapshot(b);
-    }
-
     /// Validates we can use the sparse index to fix features
     #[test]
-    #[cfg(feature = "with-crates-index")]
     fn uses_sparse_index() {
         let mut b = krates::Builder::new();
         b.with_crates_io_index(None, krates::index::IndexKind::Sparse)
@@ -290,7 +258,6 @@ mod prefer_index {
     /// Validates we can use the sparse index to fix features
     #[test]
     #[ignore = "incredibly slow if git index is missing/outdated"]
-    #[cfg(feature = "with-crates-index")]
     fn uses_git_index() {
         let mut b = krates::Builder::new();
         b.with_crates_io_index(None, krates::index::IndexKind::Git)

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -250,8 +250,7 @@ mod prefer_index {
     #[test]
     fn uses_sparse_index() {
         let mut b = krates::Builder::new();
-        b.with_crates_io_index(None, krates::index::IndexKind::Sparse)
-            .unwrap();
+        b = b.with_crates_io_index(None, None, None).unwrap();
         confirm_index_snapshot(b);
     }
 
@@ -260,8 +259,7 @@ mod prefer_index {
     #[ignore = "incredibly slow if git index is missing/outdated"]
     fn uses_git_index() {
         let mut b = krates::Builder::new();
-        b.with_crates_io_index(None, krates::index::IndexKind::Git)
-            .unwrap();
+        b = b.with_crates_io_index(None, None, Some("1.69.0")).unwrap();
         confirm_index_snapshot(b);
     }
 }


### PR DESCRIPTION
Replaces `crates-index` with `tame-index`, allowing a much cleaner interfacing with the crates.io index, and getting rid of the need for a git implementation at all as `krates` always performs a cargo_metadata retrieval which means the local .cache entries are always up to date with latest, which the change in `crates-index` to make git2 optional doesn't support since then you can't open the a git based index at all.