### PR TITLE
Remove `tame-index`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        features: ["--features targets", "--features prefer-index", null]
+        features: ["--features targets", null]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ rust-version = "1.65.0"
 
 [features]
 default = []
-# Uses the index as the source of truth for what features are available for a crate
-prefer-index = ["dep:tame-index"]
 # Adds support for filtering target specific dependencies
 targets = ["cfg-expr/targets"]
 
@@ -29,8 +27,6 @@ targets = ["cfg-expr/targets"]
 cargo_metadata = "0.17"
 # Used to parse and evaluate cfg() expressions for dependencies
 cfg-expr = "0.15"
-# Allows inspection of the cargo registry index(ices)
-tame-index = { version = "0.4", optional = true, default-features = false }
 # Used to create and traverse graph structures
 petgraph = "0.6"
 # Used for checking version requirements
@@ -44,3 +40,5 @@ insta = "1.21"
 similar-asserts = "1.1"
 # Used to deserialize test files into metadata we can load
 serde_json = "1.0"
+# index metadata retrieval
+tame-index = "0.5"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,9 +13,6 @@ pub enum Error {
     /// Due to how the graph was built, all possible root nodes were actually
     /// filtered out, leaving an empty graph
     NoRootKrates,
-    /// An error occurred trying to open or read the crates.io index
-    #[cfg(feature = "prefer-index")]
-    Index(tame_index::Error),
 }
 
 impl fmt::Display for Error {
@@ -25,8 +22,6 @@ impl fmt::Display for Error {
             Self::Metadata(err) => write!(f, "{err}"),
             Self::InvalidPkgSpec(err) => write!(f, "package spec was invalid: {err}"),
             Self::NoRootKrates => f.write_str("no root crates available"),
-            #[cfg(feature = "prefer-index")]
-            Self::Index(err) => write!(f, "{err}"),
         }
     }
 }
@@ -35,8 +30,6 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Metadata(err) => Some(err),
-            #[cfg(feature = "with-crates-index")]
-            Self::CratesIndex(err) => Some(err),
             _ => None,
         }
     }
@@ -45,12 +38,5 @@ impl std::error::Error for Error {
 impl From<CMErr> for Error {
     fn from(e: CMErr) -> Self {
         Error::Metadata(e)
-    }
-}
-
-#[cfg(feature = "prefer-index")]
-impl From<tame_index::Error> for Error {
-    fn from(e: tame_index::Error) -> Self {
-        Error::Index(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,11 +42,9 @@ mod builder;
 mod errors;
 mod pkgspec;
 
-#[cfg(feature = "prefer-index")]
-pub use builder::index;
 pub use builder::{
     features::{Feature, ParsedFeature},
-    Builder, Cmd, LockOptions, NoneFilter, OnFilter, Scope, Target,
+    index, Builder, Cmd, LockOptions, NoneFilter, OnFilter, Scope, Target,
 };
 pub use errors::Error;
 pub use pkgspec::PkgSpec;


### PR DESCRIPTION
Rather than be tied to any specific crate (or worse, specific crate version), this removes the `prefer-index` feature and the optional dependency on `tame-index` in favor of just letting the user specify a simple callback that can be used to obtain the index metadata for a set of crates. This makes end usage a bit more tedious since you have to write that code yourself, but at the same time, it's mostly going to be a write once operation that means that you can bump versions of tame-index or crates-index or whatever without needing to wait on updates to this crate, or have duplicates in your dependency graph.