### PR TITLE
Fix current dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: "clippy, rustfmt"
@@ -40,7 +40,7 @@ jobs:
         features: ["--features targets", null]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo fetch --target x86_64-unknown-linux-gnu
@@ -57,14 +57,14 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   publish-check:
     name: Publish Check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo fetch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#78](https://github.com/EmbarkStudios/krates/pull/78) fixed an issue where setting manifest_path to `Cargo.toml` without preceding `./` would cause the current directory be set to empty, and cargo_metadata to fail.
+
 ## [0.16.6] - 2024-01-24
 ### Fixed
 - [PR#77](https://github.com/EmbarkStudios/krates/pull/77) resolved [#76](https://github.com/EmbarkStudios/krates/issues/76) by special casing "wildcard" version requirements if the version being tested is a pre-release, as pre-releases must have at least one comparator.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -135,7 +135,11 @@ impl From<Cmd> for cm::MetadataCommand {
         }
 
         if let Some(cd) = cmd.current_dir {
-            mdc.current_dir(cd);
+            if !cd.as_os_str().is_empty() {
+                mdc.current_dir(cd);
+            } else {
+                mdc.current_dir(".");
+            }
         }
 
         // Everything else we specify as additional options, as MetadataCommand


### PR DESCRIPTION
If used with a bare Cargo.toml, or I suppose if a user explicitly specifies "", this would cause a failure invoking cargo-metadata