### PR TITLE
Add @ separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#96](https://github.com/EmbarkStudios/krates/pull/96) fixed an issue where package specs didn't allow the `@` separator, resolving [cargo-deny#717](https://github.com/EmbarkStudios/cargo-deny/issues/717).
+
 ## [0.17.3] - 2024-11-11
 ### Fixed
 - [PR#94](https://github.com/EmbarkStudios/krates/pull/94) fixed an issue with canonical path mismatches (I presume on Windows). Thanks [@Tastaturtaste](http://github.com/Tastaturtaste)!

--- a/src/pkgspec.rs
+++ b/src/pkgspec.rs
@@ -17,7 +17,7 @@ impl PkgSpec {
             return false;
         }
 
-        if let Some(ref vers) = self.version {
+        if let Some(vers) = &self.version {
             if vers != &krate.version {
                 return false;
             }
@@ -87,7 +87,7 @@ impl std::str::FromStr for PkgSpec {
 
             match nv {
                 Some(nv) => {
-                    match nv.find(':') {
+                    match nv.find([':', '@']) {
                         Some(ind) => {
                             if ind == nv.len() - 1 {
                                 return Err(Error::InvalidPkgSpec(
@@ -184,11 +184,13 @@ mod test {
 
     #[test]
     fn name_and_version() {
-        let spec: PkgSpec = "bitflags:1.0.4".parse().unwrap();
+        for spec in ["bitflags:1.0.4", "bitflags@1.0.4"] {
+            let spec: PkgSpec = spec.parse().unwrap();
 
-        assert_eq!("bitflags", spec.name);
-        assert_eq!(Version::parse("1.0.4").unwrap(), spec.version.unwrap());
-        assert!(spec.url.is_none());
+            assert_eq!("bitflags", spec.name);
+            assert_eq!(Version::parse("1.0.4").unwrap(), spec.version.unwrap());
+            assert!(spec.url.is_none());
+        }
     }
 
     #[test]
@@ -225,13 +227,16 @@ mod test {
 
     #[test]
     fn url_and_name_and_version() {
-        let spec: PkgSpec = "https://github.com/rust-lang/cargo#crates-io:0.21.0"
-            .parse()
-            .unwrap();
+        for spec in [
+            "https://github.com/rust-lang/cargo#crates-io:0.21.0",
+            "https://github.com/rust-lang/cargo#crates-io@0.21.0",
+        ] {
+            let spec: PkgSpec = spec.parse().unwrap();
 
-        assert_eq!("crates-io", spec.name);
-        assert_eq!(Version::parse("0.21.0").unwrap(), spec.version.unwrap());
-        assert_eq!("https://github.com/rust-lang/cargo", spec.url.unwrap());
+            assert_eq!("crates-io", spec.name);
+            assert_eq!(Version::parse("0.21.0").unwrap(), spec.version.unwrap());
+            assert_eq!("https://github.com/rust-lang/cargo", spec.url.unwrap());
+        }
     }
 
     #[test]


### PR DESCRIPTION
If I remember correctly, this implementation was based purely off of the docs, which got [updated](https://github.com/rust-lang/cargo/commit/709f1be20807cadbb6eaae2c3afcd6de65814f08) a few years ago, though presumably the implementation in cargo always supported `@`. 

Resolves: https://github.com/EmbarkStudios/cargo-deny/issues/717