### PR TITLE
Add direct dev-dependency on serde/derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 ktest = { path = "./ktest" }
+serde = { version = "1.0", features = ["derive"] }
 
 [profile.dev.package.insta]
 opt-level = 3


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Adds a direct dev-dependency on `serde/derive`; there is already a dependency on `serde`, but without the `derive` feature, which is needed for the `cm::Package::metadata` doctest.

This might be considered kind of pedantic, because the tests already pass in a git checkout due to a combination of indirect dependencies via the `ktest` path-based dev-dependency, its direct and indirect dependencies, and feature unification, but this is not necessarily guaranteed to work forever, and explicit is better than implicit.

This also helps downstream in Fedora, where we (by policy) use the crates.io package as the source for our [`rust-krates`](https://src.fedoraproject.org/rpms/rust-krates/) package, so we are running the lib and doc tests without the separate integration tests and without the `ktest` path-based dev-dependency.

To demonstrate that `cm::Package::metadata` requires `serde/derive`, just comment out the line

https://github.com/EmbarkStudios/krates/blob/7ab8f2cb182e732f925ff4ca6894fd856a152440/Cargo.toml#L39

and then run `cargo test --doc`:

```

failures:

---- src/cm.rs - cm::Package::metadata (line 296) stdout ----
error: cannot find derive macro `Deserialize` in this scope
   --> src/cm.rs:300:17
    |
300 | #[derive(Debug, Deserialize)]
    |                 ^^^^^^^^^^^
    |
note: `Deserialize` is imported here, but it is only a trait, without a derive macro
   --> src/cm.rs:297:5
    |
297 | use serde::Deserialize;
    |     ^^^^^^^^^^^^^^^^^^

error[E0277]: the trait bound `SomePackageMetadata: serde::de::DeserializeOwned` is not satisfied
    --> src/cm.rs:309:45
     |
 309 | let package_metadata: SomePackageMetadata = serde_json::from_value(value).unwrap();
     |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
help: the trait `for<'de> Deserialize<'de>` is not implemented for `SomePackageMetadata`
    --> src/cm.rs:301:1
     |
 301 | struct SomePackageMetadata {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: the following other types implement trait `Deserialize<'de>`:
               &'a Path
               &'a [u8]
               &'a camino::Utf8Path
               &'a str
               ()
               (T,)
               (T0, T1)
               (T0, T1, T2)
             and 162 others
     = note: required for `SomePackageMetadata` to implement `DeserializeOwned`
note: required by a bound in `from_value`
    --> /home/ben/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde_json-1.0.149/src/value/mod.rs:1039:8
     |
1037 | pub fn from_value<T>(value: Value) -> Result<T, Error>
     |        ---------- required by a bound in this function
1038 | where
1039 |     T: DeserializeOwned,
     |        ^^^^^^^^^^^^^^^^ required by this bound in `from_value`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0277`.
Couldn't compile the test.

failures:
    src/cm.rs - cm::Package::metadata (line 296)

test result: FAILED. 12 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.23s
```

### Related Issues

N/A